### PR TITLE
 #2: Fix Docker usage remote MCP image URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Model Context Protocol server that provides access to Valyu's knowledge retrie
 
 ```bash
 docker pull ghcr.io/tiovikram/valyu-mcp-server
-docker run -i --rm -e VALYU_API_KEY=your-api-key tiovikram/valyu-mcp-server
+docker run -i --rm -e VALYU_API_KEY=your-api-key ghcr.io/tiovikram/valyu-mcp-server
 ```
 
 ## Configuration
@@ -46,7 +46,7 @@ Add to your Claude settings:
 "mcpServers": {
   "valyu": {
     "command": "docker",
-    "args": ["run", "--rm", "-i", "-e", "VALYU_API_KEY", "tiovikram/valyu-mcp-server"],
+    "args": ["run", "--pull", "--rm", "-i", "-e", "VALYU_API_KEY", "ghcr.io/tiovikram/valyu-mcp-server"],
     "env": {
       "VALYU_API_KEY": "<your-valyu-api-key>"
     }


### PR DESCRIPTION
  * Change the README.md remote image URL to "ghcr.io/tiovikram/valyu-mcp-server" instead of "tiovikram/valyu-mcp-server"
  * Change the run instructions for claude_desktop_config.json to pull image if missing with "--pull" flag
  
  ## What
[README.md](https://github.com/tiovikram/valyu-mcp-js/blob/master/README.md) currently says the following in setup instructions

**Test with Docker instructions**
```bash
docker pull ghcr.io/tiovikram/valyu-mcp-server
docker run -i --rm -e VALYU_API_KEY=your-api-key tiovikram/valyu-mcp-server
```

**Claude Desktop Config installation**
```json
"mcpServers": {
  "valyu": {
    "command": "docker",
    "args": ["run", "--rm", "-i", "-e", "VALYU_API_KEY", "tiovikram/valyu-mcp-server"],
    "env": {
      "VALYU_API_KEY": "<your-valyu-api-key>"
    }
  }
}
```

## Why
This will not work since the correct image address is `ghcr.io/tiovikram/valyu-mcp-server`

## How
Change the image address in [README.md](https://github.com/tiovikram/valyu-mcp-js/blob/master/README.md)